### PR TITLE
Fix PDF embedding example

### DIFF
--- a/embedding_pdf_documents/README.md
+++ b/embedding_pdf_documents/README.md
@@ -49,6 +49,8 @@ Once all the worker nodes have started, run the [Ray batch inference code](embed
 `python embedding_ray.py`
 
 ## Step 10
-After the workload finished, tear down the cluster
+
+After the workload finished, tear down the cluster! This needs to be run from outside the cluster, so if you are
+still in the cluster shell, make sure to exit with Control-C.
 
 `ray down llm-batch-inference.yaml`

--- a/embedding_pdf_documents/README.md
+++ b/embedding_pdf_documents/README.md
@@ -8,45 +8,9 @@ The full Ray cluster launcher documentation can be found [here](https://docs.ray
 Install Ray locally: `pip install 'ray[default]'`
 
 ## Step 2
-Download the [following cluster yaml file](llm-batch-inference.yaml) locally:
-
-```yaml
-# An unique identifier for the head node and workers of this cluster.
-cluster_name: llm-batch-inference
-
-max_workers: 5
-
-# Cloud-provider specific configuration.
-provider:
-    type: aws
-    region: us-west-2
-    # In case you need to specify a pre-generated EC2 SSH key.
-    # In this case, you need to download the key from the EC2 console, 
-    # move it to your ~/.ssh/ directory and grant the correct permissions like `chmod 400 ~/.ssh/llm-blogpost-test-key.pem`
-    # Then, uncomment the below lines and replace `key_name` with the name of your key:
-    # key_pair:
-    #   key_name: llm-blogpost-test-key
-
-available_node_types:
-  ray.head.default:
-      resources: {"CPU": 48, "GPU": 4}
-      node_config:
-        InstanceType: g4dn.12xlarge
-        BlockDeviceMappings:
-            - DeviceName: /dev/sda1
-              Ebs:
-                  VolumeSize: 200
-  ray.worker.default:
-      node_config:
-        InstanceType: g4dn.12xlarge
-        BlockDeviceMappings:
-            - DeviceName: /dev/sda1
-              Ebs:
-                  VolumeSize: 200
-      resources: {"CPU": 48, "GPU": 4}
-      min_workers: 4
-      max_workers: 4
-```
+Clone the repository `git clone https://github.com/ray-project/langchain-ray/` and switch into the directory
+`cd langchain-ray`.
+You can edit the [cluster yaml file](llm-batch-inference.yaml) if you need to make changes.
 
 ## Step 3
 Setup the necessary AWS credentials (set the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN` environment variables).
@@ -83,3 +47,8 @@ Install the requirements on the head node of the cluster
 Once all the worker nodes have started, run the [Ray batch inference code](embedding_ray.py) on the cluster!
 
 `python embedding_ray.py`
+
+## Step 10
+After the workload finished, tear down the cluster
+
+`ray down llm-batch-inference.yaml`

--- a/embedding_pdf_documents/README.md
+++ b/embedding_pdf_documents/README.md
@@ -50,7 +50,7 @@ Once all the worker nodes have started, run the [Ray batch inference code](embed
 
 ## Step 10
 
-After the workload finished, tear down the cluster! This needs to be run from outside the cluster, so if you are
+After the workload finished, tear down the cluster! This needs to be run from your laptop, so if you are
 still in the cluster shell, make sure to exit with Control-C.
 
 `ray down llm-batch-inference.yaml`

--- a/embedding_pdf_documents/llm-batch-inference.yaml
+++ b/embedding_pdf_documents/llm-batch-inference.yaml
@@ -7,8 +7,19 @@ max_workers: 5
 provider:
     type: aws
     region: us-west-2
-    key_pair:
-      key_name: llm-blogpost-test-pcm
+    # In case you need to specify a pre-generated EC2 SSH key.
+    # In this case, you need to download the key from the EC2 console,
+    # move it to your ~/.ssh/ directory and grant the correct permissions like `chmod 400 ~/.ssh/llm-blogpost-test-key.pem`
+    # Then, uncomment the below lines and replace `key_name` with the name of your key:
+    # key_pair:
+    #   key_name: llm-blogpost-test-key
+
+# List of shell commands to run to set up nodes.
+setup_commands:
+    - >-
+        (stat $HOME/anaconda3/envs/tensorflow2_p38/ &> /dev/null &&
+        echo 'export PATH="$HOME/anaconda3/envs/tensorflow2_p38/bin:$PATH"' >> ~/.bashrc) || true
+    - which ray || pip install -U "ray[default]"
 
 available_node_types:
   ray.head.default:


### PR DESCRIPTION
Originally, the Ray cluster launcher installed a nightly Ray due to https://github.com/ray-project/ray/blob/master/python/ray/autoscaler/aws/defaults.yaml#LL122C1-L127C48

This led to a problem with recent upstream changes.

Also I did some de-duping of the cluster yaml file and added instructions to tear down the cluster.